### PR TITLE
Minor README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,8 @@ This plugin wires the two up so you can use Cloudinary images in your blog posts
 articles, product pages, site templates, and anywhere else you might need to
 reference media optimized for mobile and responsive design.
 
-(_Note: For users who may be familiar with the jekyll-cloudinary plugin, this is
-unrelated and the usage is quite different. This plugin assumes you store your
-images in Cloudinary directly, not your repo._)
+> __Note__<br />
+> For users who may be familiar with the [jekyll-cloudinary](https://github.com/nhoizey/jekyll-cloudinary) plugin, this is unrelated and the usage is quite different. This plugin assumes you store your images in Cloudinary directly, not your repo.
 
 ## Installation
 
@@ -36,7 +35,8 @@ init :"bridgetown-cloudinary" do
 end
 ```
 
-(For Bridgetown 1.1 or earlier, [read these instructions](https://github.com/bridgetownrb/bridgetown-cloudinary/tree/v1.2.0).)
+> __Note__<br />
+> For __Bridgetown 1.1__ or earlier, [read these instructions](https://github.com/bridgetownrb/bridgetown-cloudinary/tree/v1.2.0).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ own.)
 
 You can use `image.path` in a template:
 
-`{{ post.image.path }}`
+```liquid
+{{ post.image.path }}
+```
 
 Since `image.path` is also referenced by the Bridgetown [Feed](https://github.com/bridgetownrb/bridgetown-feed) and [SEO](https://github.com/bridgetownrb/bridgetown-seo-tag) plugins,
 your Cloudinary images will be picked up in those contexts automatically.
@@ -69,17 +71,29 @@ your Cloudinary images will be picked up in those contexts automatically.
 To reference other available sizes, you can use either a Liquid tag or filter, or Ruby helper,
 depending on your needs. Using a tag:
 
-`{% cloudinary_img "Alt text goes here", post.cloudinary_id, "large" %}`
+```liquid
+{% cloudinary_img "Alt text goes here", post.cloudinary_id, "large" %}
+```
 
 Or a filter:
 
-`<img alt="Alt text" src="{{ post.cloudinary_id | cloudinary_url: "medium" }}" />`
+```liquid
+<img alt="Alt text"
+     src="{{ post.cloudinary_id | cloudinary_url: "medium" }}"
+     />
+```
 
 Or helpers in ERB and other Ruby templates:
 
-`<%= cloudinary_img "Alt text goes here", post.data.cloudinary_id %>`
+```erb
+<%= cloudinary_img "Alt text goes here", post.data.cloudinary_id %>
+```
 
-`<img alt="Alt text" src="<%= cloudinary_url post.data.cloudinary_id, :medium %>" />`
+```erb
+<img alt="Alt text"
+     src="<%= cloudinary_url post.data.cloudinary_id, :medium %>"
+     />
+```
 
 ### Default Sizes Included
 
@@ -109,7 +123,11 @@ cloudinary:
 
 Then you'll be able to reference image sizes like so:
 
-`<img alt="Alt text" src="{{ post.image.tiny }}" />`
+```liquid
+<img alt="Alt text"
+     src="{{ post.image.tiny }}"
+     />
+```
 
 Be aware that if an `image` front matter variable has already defined for a document,
 it will remain intact and the Cloudinary image transformations won't be apply for
@@ -128,7 +146,9 @@ cloudinary:
 If you configure transformations to get added to front matter, all custom
 transformations will show up there as well:
 
-`B&W image URL: {{ post.image.max_bw }}`
+```liquid
+B&W image URL: {{ post.image.max_bw }}
+```
 
 ## Testing
 


### PR DESCRIPTION
## Note Blocks
GFM actually supports specially-formatted 'quote' blocks for __Warnings__ and __Notes__, which can be made like this:

```markdown
> __Warning__<br />
> This is a Warning.

This is some boring, regular text.

> __Note__<br />
> This is a Note.
```

> __Warning__
> While the hard `<br />` break is necessary for things like README documents and Wikis, it is __*not*__ required for things like Discussion Posts, Issues, and Pull Requests. So make sure you preview them before you post.

As an example, that Warning block does not have a hard break following __Warning__.

It took me forever to figure out how to make them (because apparently there's no documentation for it at all) and I figured you'd enjoy them.



## Additional Syntax Highlighting
I always appreciate when creators take the time to properly format their documentation so that everyone else can more easily understand it, so thanks for being thorough.

However I noticed the Liquid and ERB examples you added were done in basic `code spans`, which made them a little difficult to follow on a phone with word wrapping.

If you didn't know, `liquid` and `erb` are both valid declarations for code blocks, and they include HTML highlighting in addition to the template syntax.


Let me know if you have any questions about this, and I hope it helps- and I'm looking forward to trying out the plugin soon. 😎